### PR TITLE
Replace openbabel-wheel with openbabel package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dynamic = ["version"]
 Homepage = "https://thangckt.github.io/asext_doc"
 
 [project.optional-dependencies]
-all = ["openbabel-wheel", "ase", "numpy"]
+all = ["openbabel>=3.2.0", "ase", "numpy"]
 bare = []
 test = ["pytest", "pytest-cov", "numpy"]
 


### PR DESCRIPTION
This pull request updates the dependency specification for the `all` optional dependency group in `pyproject.toml` to require a specific minimum version of `openbabel`.

Dependency updates:

* Changed the `all` optional dependency from `"openbabel-wheel"` to `"openbabel>=3.2.0"`, ensuring a minimum version and aligning with standard package naming. (`pyproject.toml`)